### PR TITLE
fix: use non-lib prefix for linkSystemLibrary

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
-    lib.linkSystemLibrary("libevdev", .{
+    lib.linkSystemLibrary("evdev", .{
         .needed = true,
         .preferred_link_mode = .dynamic,
     });


### PR DESCRIPTION
In the non-dev version of 0.12+ `linkSystemLibrary` strips `lib` from the name.

This change allows newer versions of zig to utilize this library.

Feel free to decline or merge whenever is convenient.

Thanks!